### PR TITLE
docs: add MAINTAINERS.md

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,14 @@
+# Maintainers
+
+This file lists the people responsible for this repository. See the org-wide
+[GOVERNANCE.md](https://github.com/floci-io/.github/blob/main/GOVERNANCE.md) for roles and the
+path to becoming a Maintainer.
+
+## Lead Maintainer
+- Hector Ventura (@hectorvent): final authority across the project.
+
+## Maintainers (this repository)
+- Hector Ventura (@hectorvent): Floci Duck, the DuckDB executor sidecar.
+
+## Emeritus
+- (none yet)


### PR DESCRIPTION
## Why

The org-wide [GOVERNANCE.md](https://github.com/floci-io/.github/blob/main/GOVERNANCE.md) says, under the Maintainer role:

> Maintainers are listed in each repository's `MAINTAINERS.md`.

No repository in the org had one. This is part of a rollout that makes that sentence true across `floci-io`.

## What

`MAINTAINERS.md`, a verbatim copy of the org-level template with the entry changed, so the family stays one shape rather than seventeen dialects.

`GOVERNANCE.md` is deliberately **not** copied here. It is one of GitHub's supported default community health files, so it is already inherited from `floci-io/.github`, and a local copy would silently override the inherited one. The template links it by absolute URL instead.

This repository has one maintainer today. Saying so in the repo is more useful than leaving the question unanswered.

## Verification

Documentation only. No code, build inputs, or runtime behavior touched.